### PR TITLE
Refactor: Introduce modular RenderPipeline with Shadow and Scene passes

### DIFF
--- a/YinYang/Behaviors/CamMoveBehavior.cs
+++ b/YinYang/Behaviors/CamMoveBehavior.cs
@@ -9,14 +9,24 @@ namespace YinYang.Behaviors;
 /// </summary>
 public class CamMoveBehavior(GameObject gameObject, Game window) : Behaviour(gameObject, window)
 {
+    private Camera cameraComponent;
+    
     private Vector3 front = new Vector3(0.0f, 0.0f, -1.0f);
     private Vector3 up = new Vector3(0.0f, 1.0f, 0.0f);
     private float speed = 10.0f;
     private float sensitivity = 10.0f;
-    private readonly Camera cameraComponent = gameObject.GetComponent<Camera>();
 
     public override void Update(FrameEventArgs args)
     {
+        if (cameraComponent == null)
+            cameraComponent = gameObject.GetComponent<Camera>();
+
+        if (cameraComponent == null)
+        {
+            Console.WriteLine("CamMoveBehavior: Camera component not found.");
+            return;
+        }
+        
         KeyboardState input = window.KeyboardState;
         MouseState mouse = window.MouseState;
 

--- a/YinYang/Camera.cs
+++ b/YinYang/Camera.cs
@@ -1,5 +1,7 @@
 ﻿using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 using YinYang.Behaviors;
 
 namespace YinYang
@@ -15,10 +17,16 @@ namespace YinYang
         private float far;
         
         public Vector3 Position => gameObject.Transform.Position;
+        
+        private readonly GameWindow window;
 
+        public int RenderWidth => window.Size.X;
+        public int RenderHeight => window.Size.Y;
 
         public Camera(GameObject gameObject, Game window, float FOV, float aspectX, float aspectY,float near,float far) : base(gameObject, window)
         {
+            this.window = window;
+            
             gameObject.Transform.Position = new Vector3(0.0f, 0.0f, 5.0f);
             gameObject.Transform.Rotation = new Vector3(0.0f, -90.0f, 0.0f);
             this.FOV = FOV;
@@ -32,6 +40,9 @@ namespace YinYang
         { 
             //Movement moved -> CamMoveBehavior.cs
         }
+        
+        public virtual void HandleInput(KeyboardState input) { }
+
         public Matrix4 GetViewProjection()
         {
             Matrix4 view = Matrix4.LookAt(gameObject.Transform.Position, gameObject.Transform.Position + Front, Up);

--- a/YinYang/GameObject.cs
+++ b/YinYang/GameObject.cs
@@ -3,6 +3,7 @@ using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
 using YinYang.Behaviors;
 using YinYang.Components;
+using YinYang.Rendering;
 using YinYang.Worlds;
 
 namespace YinYang
@@ -64,7 +65,7 @@ namespace YinYang
             }
         }
 
-        public void Draw(Matrix4 viewProjection, Matrix4 lightSpaceMatrix,  Camera camera, World currentWorld, int debugMode = 0)
+        public void Draw(Matrix4 viewProjection, Matrix4 lightSpaceMatrix, Camera camera, World currentWorld, int debugMode = 0)
         {
             if (Renderer != null)
             {

--- a/YinYang/GameObjectBuilder.cs
+++ b/YinYang/GameObjectBuilder.cs
@@ -2,6 +2,7 @@ using OpenTK.Mathematics;
 using YinYang.Behaviors;
 using YinYang.Components;
 using YinYang.Materials;
+using YinYang.Rendering;
 
 namespace YinYang;
 

--- a/YinYang/GameObjectFactory.cs
+++ b/YinYang/GameObjectFactory.cs
@@ -2,6 +2,7 @@ using YinYang.Components;
 using YinYang.Shapes;
 using OpenTK.Mathematics;
 using YinYang.Materials;
+using YinYang.Rendering;
 
 namespace YinYang;
 

--- a/YinYang/Managers/CameraManager.cs
+++ b/YinYang/Managers/CameraManager.cs
@@ -1,6 +1,7 @@
 using OpenTK.Mathematics;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 using YinYang.Behaviors;
 
 namespace YinYang.Managers
@@ -45,6 +46,25 @@ namespace YinYang.Managers
             // Lock and focus the cursor inside the game window.
             game.CursorState = CursorState.Grabbed;
         }
+        
+        /// <summary>
+        /// Updates the camera's internal state and any attached behaviors.
+        /// </summary>
+        /// <param name="args">Frame timing information.</param>
+        public void Update(FrameEventArgs args)
+        {
+            Camera?.Update(args);
+        }
+        
+        /// <summary>
+        /// Handles keyboard input for the camera.
+        /// </summary>
+        /// <param name="input">Current keyboard state.</param>
+        public void HandleInput(KeyboardState input)
+        {
+            Camera?.HandleInput(input);
+        }
+
 
         /// <summary>
         /// Returns the view-projection matrix from the active camera.

--- a/YinYang/Managers/ObjectManager.cs
+++ b/YinYang/Managers/ObjectManager.cs
@@ -47,6 +47,13 @@ namespace YinYang.Managers
             // Iterate through and draw each GameObject with appropriate matrices and lighting context.
             foreach (var obj in GameObjects)
             {
+                if (obj.Renderer == null) //TODO: maybe seperate lists for renderers and non-renderers
+                {
+                    // If the object has no renderer, skip it.
+                    //Console.WriteLine($"ObjectManager.Render: Object at {obj.Transform.Position} has no Renderer.");
+                    continue;
+                }
+                
                 obj.Draw(viewProjection, lightSpaceMatrix, camera, currentWorld, debugMode);
             }
         }

--- a/YinYang/Rendering/RenderPass.cs
+++ b/YinYang/Rendering/RenderPass.cs
@@ -1,0 +1,43 @@
+using OpenTK.Mathematics;
+using YinYang.Managers;
+using YinYang.Worlds;
+
+namespace YinYang.Rendering
+{
+    /// <summary>
+    /// Abstract base class for all modular render passes in the pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Defines a common interface for executing and cleaning up rendering stages.
+    /// Provides optional toggling and naming support for diagnostics and control.
+    /// </remarks>
+    public abstract class RenderPass
+    {
+        /// <summary>
+        /// Indicates whether this pass should be executed.
+        /// </summary>
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// A human-readable identifier for the render pass.
+        /// </summary>
+        public virtual string Name => GetType().Name;
+
+        /// <summary>
+        /// Executes the render pass with access to scene data and rendering context.
+        /// </summary>
+        /// <param name="camera">The active camera.</param>
+        /// <param name="lighting">Scene lighting data.</param>
+        /// <param name="objects">Scene objects to render.</param> //TODO: maybe decouple objectmanger and use list or delegate for objects to render
+        /// <param name="lightSpaceInput">Input matrix from previous pass, typically identity or shadow transform.</param>
+        /// <param name="currentWorld">The current world instance.</param>
+        /// <returns>The updated light-space matrix.</returns>
+        public abstract Matrix4 Execute(Camera camera, LightingManager lighting, ObjectManager objects, Matrix4 lightSpaceInput, World currentWorld);
+
+
+        /// <summary>
+        /// Frees GPU resources used by this pass.
+        /// </summary>
+        public abstract void Dispose();
+    }
+}

--- a/YinYang/Rendering/Renderer.cs
+++ b/YinYang/Rendering/Renderer.cs
@@ -3,7 +3,7 @@ using OpenTK.Mathematics;
 using YinYang.Materials;
 using YinYang.Worlds;
 
-namespace YinYang.Components
+namespace YinYang.Rendering
 {
     public class Renderer
     {
@@ -38,11 +38,12 @@ namespace YinYang.Components
             Material.SetUniform("mvp", mvp);
             Material.SetUniform("model", model);
             Material.SetUniform("lightSpaceMatrix", lightSpaceMatrix);
+        
             Material.SetUniform("shadowMap", currentWorld.depthMap);
 
             Matrix4 normalMatrix = Matrix4.Invert(model);
 
-            Material.SetUniform("normalMatrix", normalMatrix); // Correct normal matrix passed to the shader
+            Material.SetUniform("normalMatrix", normalMatrix); 
 
             SetSun(currentWorld);
             SpotLights(camera, currentWorld);

--- a/YinYang/Rendering/SceneRenderPass.cs
+++ b/YinYang/Rendering/SceneRenderPass.cs
@@ -1,0 +1,49 @@
+using OpenTK.Graphics.OpenGL4;
+using OpenTK.Mathematics;
+using YinYang.Managers;
+using YinYang.Worlds;
+
+namespace YinYang.Rendering
+{
+    /// <summary>
+    /// Render pass responsible for rendering the visible scene from the camera's perspective.
+    /// </summary>
+    /// <remarks>
+    /// This pass renders all scene objects into the default framebuffer, using lighting and shadow data.
+    /// </remarks>
+    public class SceneRenderPass : RenderPass
+    {
+        /// <summary>
+        /// Executes the scene render pass from the camera's viewpoint.
+        /// </summary>
+        /// <param name="camera">The active camera for view/projection transforms.</param>
+        /// <param name="lighting">Lighting manager providing light data.</param>
+        /// <param name="objects">Scene objects to render.</param>
+        /// <param name="lightSpaceMatrix">Matrix used to transform world space into light space for shadows.</param>
+        /// <param name="currentWorld">The current world instance.</param>
+        /// <returns>Returns the input light-space matrix unmodified.</returns>
+        public override Matrix4 Execute(Camera camera, LightingManager lighting, ObjectManager objects, Matrix4 lightSpaceMatrix, World currentWorld)
+        {
+            // Set OpenGL viewport dimensions to match window size
+            GL.Viewport(0, 0, camera.RenderWidth, camera.RenderHeight);
+
+            // Clear the color and depth buffers before drawing
+            GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+
+            // Compute the view-projection matrix for this frame
+            // This transforms world space into clip space from the camera's point of view
+            Matrix4 viewProjection = camera.GetViewProjection();
+
+            // Render all objects using lighting and transformation data
+            objects.Render(viewProjection, lightSpaceMatrix, camera, currentWorld, 0); // TODO: replace currentWorld and 0 with render context and debug mode as needed
+
+            // Return the same light-space matrix to pass along to any subsequent render passes
+            return lightSpaceMatrix;
+        }
+
+        /// <summary>
+        /// Releases any resources used by this render pass. Not used in this case.
+        /// </summary>
+        public override void Dispose() { }
+    }
+}

--- a/YinYang/Rendering/ShadowRenderPass.cs
+++ b/YinYang/Rendering/ShadowRenderPass.cs
@@ -1,0 +1,127 @@
+using OpenTK.Graphics.OpenGL4;
+using OpenTK.Mathematics;
+using YinYang.Managers;
+using YinYang.Worlds;
+
+namespace YinYang.Rendering
+{
+    /// <summary>
+    /// Render pass responsible for generating the directional light shadow depth map.
+    /// </summary>
+    /// <remarks>
+    /// This pass renders the scene from the sun's perspective into a depth-only framebuffer,
+    /// creating a shadow map used for directional shadowing in the main scene pass.
+    /// </remarks>
+    public class ShadowRenderPass : RenderPass
+    {
+        private int framebufferHandle;
+        private int shadowResolution = 4096;
+        private Shader shadowShader;
+        private Texture shadowDepthTexture;
+
+        /// <summary>
+        /// The depth texture produced by this shadow pass.
+        /// </summary>
+        public Texture ShadowDepthTexture => shadowDepthTexture;
+
+        /// <summary>
+        /// Initializes the framebuffer, depth texture, and shader required for shadow rendering.
+        /// </summary>
+        public ShadowRenderPass()
+        {
+            // Load the shader responsible for writing depth values only
+            shadowShader = new Shader("Shaders/DirDepth.vert", "Shaders/DirDepth.frag");
+
+            // Create a framebuffer object that will render depth from the light's perspective
+            framebufferHandle = GL.GenFramebuffer();
+
+            // Create a 2D depth texture to store the light's depth map
+            int textureHandle = GL.GenTexture();
+            GL.BindTexture(TextureTarget.Texture2D, textureHandle);
+            GL.TexImage2D(
+                TextureTarget.Texture2D,
+                0,
+                PixelInternalFormat.DepthComponent,
+                shadowResolution,
+                shadowResolution,
+                0,
+                PixelFormat.DepthComponent,
+                PixelType.Float,
+                IntPtr.Zero);
+
+            // Set texture parameters to avoid interpolation and ensure edge clamp
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Nearest);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)TextureWrapMode.ClampToBorder);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)TextureWrapMode.ClampToBorder);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBorderColor, new float[] { 1, 1, 1, 1 });
+
+            // Attach the depth texture to the framebuffer and disable color writes
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferHandle);
+            GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, TextureTarget.Texture2D, textureHandle, 0);
+            GL.DrawBuffer(DrawBufferMode.None);
+            GL.ReadBuffer(ReadBufferMode.None);
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+
+            // Wrap the raw texture handle in a reusable abstraction
+            shadowDepthTexture = new Texture(textureHandle);
+        }
+
+         /// <summary>
+    /// Executes the shadow pass by rendering the scene from the directional light's perspective.
+    /// </summary>
+    /// <remarks>
+    /// Produces a light-space transformation matrix which is used in subsequent passes
+    /// to compare fragment depth against shadow depth for shadow testing.
+    /// </remarks>
+    /// <param name="camera">The active camera.</param>
+    /// <param name="lighting">The lighting manager containing sun and light data.</param>
+    /// <param name="objects">The object manager with all scene objects.</param>
+    /// <param name="lightSpaceInput">Input light-space matrix (typically identity).</param>
+    /// <param name="currentWorld">The current world instance. (Not used in this pass but required by the signature.)</param>
+    /// <returns>The computed light-space transformation matrix.</returns>
+    public override Matrix4 Execute(Camera camera, LightingManager lighting, ObjectManager objects, Matrix4 lightSpaceInput, World currentWorld)
+    {
+        // Orthographic projection to simulate infinite directional light projection.
+        Matrix4 lightProjection = Matrix4.CreateOrthographicOffCenter(-10.0f, 10.0f, -10f, 10f, 0.1f, 50.0f);
+
+        // Create a view matrix from the light's position looking along its rotation vector.
+        Matrix4 lightView = Matrix4.LookAt(
+            lighting.Sun.Transform.Position,
+            lighting.Sun.Transform.Position + lighting.Sun.Transform.Rotation,
+            Vector3.UnitY);
+
+        // Combine projection and view to form the light-space matrix.
+        Matrix4 lightSpaceMatrix = lightView * lightProjection;
+
+        // Activate the shader and set the light-space matrix.
+        shadowShader.Use();
+        shadowShader.SetMatrix("lightSpaceMatrix", lightSpaceMatrix);
+
+        // Configure the viewport to match the shadow resolution.
+        GL.Viewport(0, 0, shadowResolution, shadowResolution);
+
+        // Bind the depth-only framebuffer and clear it.
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferHandle);
+        GL.Clear(ClearBufferMask.DepthBufferBit);
+
+        // Render all scene geometry from the light's point of view.
+        objects.RenderDepth(shadowShader);
+
+        // Unbind the framebuffer to return to the default target.
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+
+        // Return the transformation matrix for use in the main lighting pass.
+        return lightSpaceMatrix;
+    }
+
+        /// <summary>
+        /// Releases GPU resources used by this render pass.
+        /// </summary>
+        public override void Dispose()
+        {
+            shadowShader.Dispose();
+            GL.DeleteFramebuffer(framebufferHandle);
+        }
+    }
+}


### PR DESCRIPTION
- Added RenderPass base class and modular render pipeline architecture
- Implemented ShadowRenderPass and SceneRenderPass
- Converted World to use RenderPipeline with AddPass/RenderAll
- Preserved legacy access to depthMap via passthrough
- Prevented crashes from null Renderer.Material
- Removed camera GameObject from render list and handled update/input via CameraManager
- Ensured CamMoveBehavior remains active through manual GameObject update call