### PR TITLE
refactor: clean up Renderer lighting responsibilities

### DIFF
--- a/YinYang/Materials/LightingUniforms.cs
+++ b/YinYang/Materials/LightingUniforms.cs
@@ -1,0 +1,75 @@
+using OpenTK.Mathematics;
+using YinYang.Rendering;
+using YinYang.Worlds;
+
+namespace YinYang.Materials;
+
+/// <summary>
+/// Provides shared helper methods for applying lighting uniforms to materials.
+/// </summary>
+public static class LightingUniforms
+{
+    /// <summary>
+    /// Applies all standard lighting uniforms to the given material,
+    /// including sun, point lights, spot lights, and shadows.
+    /// </summary>
+    public static void ApplyStandardLighting(Material mat, RenderContext context)
+    {
+        var world = context.World;
+        var camera = context.Camera;
+
+        mat.SetUniform("lightSpaceMatrix", context.LightSpaceMatrix);
+        mat.SetUniform("shadowMap", world.depthMap);
+        
+        // if there is a cube map, set the cube map and far plane
+        if (context.World.depthCubeMap != null)
+        {
+            mat.SetUniform("cubeMap", context.World.depthCubeMap);
+            mat.SetUniform("far_plane", 50.0f);
+        }
+
+
+        mat.SetUniform("dirLight.direction", world.DirectionalLight.Transform.Rotation);
+        mat.SetUniform("dirLight.ambient", world.GetSkyColor() / 2);
+        mat.SetUniform("dirLight.diffuse", world.DirectionalLight.LightColor);
+        mat.SetUniform("dirLight.specular", world.DirectionalLight.LightColor);
+
+        mat.SetUniform("numPointLights", world.PointLights.Count);
+        for (int i = 0; i < world.PointLights.Count; i++)
+        {
+            var light = world.PointLights[i];
+            mat.SetUniform($"pointLights[{i}].position", light.Transform.Position);
+            mat.SetUniform($"pointLights[{i}].ambient", world.GetSkyColor() / 255);
+            mat.SetUniform($"pointLights[{i}].diffuse", light.LightColor);
+            mat.SetUniform($"pointLights[{i}].specular", light.LightColor);
+            mat.SetUniform($"pointLights[{i}].constant", light.Constant);
+            mat.SetUniform($"pointLights[{i}].linear", light.Linear);
+            mat.SetUniform($"pointLights[{i}].quadratic", light.Quadratic);
+        }
+
+        mat.SetUniform("numSpotLights", world.SpotLights.Count);
+        for (int i = 0; i < world.SpotLights.Count; i++)
+        {
+            var light = world.SpotLights[i];
+            if (i == 0)
+            {
+                mat.SetUniform($"spotLights[{i}].position", camera.Position);
+                mat.SetUniform($"spotLights[{i}].direction", Vector3.Normalize(camera.Front));
+            }
+            else
+            {
+                mat.SetUniform($"spotLights[{i}].position", light.Transform.Position);
+                mat.SetUniform($"spotLights[{i}].direction", light.Transform.Rotation);
+            }
+
+            mat.SetUniform($"spotLights[{i}].cutOff", (float)MathHelper.Cos(MathHelper.DegreesToRadians(light.InnerRadius)));
+            mat.SetUniform($"spotLights[{i}].outerCutOff", (float)MathHelper.Cos(MathHelper.DegreesToRadians(light.OuterRadius)));
+            mat.SetUniform($"spotLights[{i}].ambient", world.GetSkyColor() / 255);
+            mat.SetUniform($"spotLights[{i}].diffuse", light.LightColor);
+            mat.SetUniform($"spotLights[{i}].specular", light.LightColor);
+            mat.SetUniform($"spotLights[{i}].constant", light.Constant);
+            mat.SetUniform($"spotLights[{i}].linear", light.Linear);
+            mat.SetUniform($"spotLights[{i}].quadratic", light.Quadratic);
+        }
+    }
+}

--- a/YinYang/Materials/Material.cs
+++ b/YinYang/Materials/Material.cs
@@ -1,5 +1,6 @@
 ﻿using OpenTK.Graphics.OpenGL4;
 using OpenTK.Mathematics;
+using YinYang.Rendering;
 
 namespace YinYang.Materials
 {
@@ -9,14 +10,22 @@ namespace YinYang.Materials
     public class Material : IDisposable
     {
         protected Shader shader;
-        protected Dictionary<string, object> uniforms = new Dictionary<string, object>();
-        private Dictionary<int, Texture> textures = new Dictionary<int, Texture>();
+        protected Dictionary<string, object> uniforms = new();
+        private Dictionary<int, Texture> textures = new();
 
-        /// <summary>
-        /// Enables debug logging for GL errors and invalid states.
-        /// </summary>
+        /// <summary>Enables GL error debug output during SetUniform().</summary>
         public static bool MaterialDebug = false;
 
+        /// <summary>Indicates whether this material uses scene lighting.</summary>
+        public virtual bool UsesLighting => true;
+
+        /// <summary>
+        /// Called only if <c>UsesLighting</c> is true.
+        /// Materials can override to push lighting-specific uniforms.
+        /// </summary>
+        public virtual void PrepareLighting(RenderContext context) { }
+
+        
         public void UpdateUniforms()
         {
             foreach (KeyValuePair<string, object> uniform in uniforms)

--- a/YinYang/Materials/mat_chrome.cs
+++ b/YinYang/Materials/mat_chrome.cs
@@ -1,7 +1,11 @@
 using OpenTK.Mathematics;
+using YinYang.Rendering;
 
 namespace YinYang.Materials;
 
+/// <summary>
+/// Chrome material with high specular intensity and shininess.
+/// </summary>
 public class mat_chrome : Material
 {
     public mat_chrome() : base()
@@ -12,7 +16,15 @@ public class mat_chrome : Material
         uniforms.Add("material.diffuse", new Vector3(0.6f));
         uniforms.Add("material.specular", new Vector3(0.774f));
         uniforms.Add("material.shininess", 96.8f);
-        
+
         UpdateUniforms();
+    }
+
+    /// <summary>
+    /// Set all lighting uniforms required by this chrome mat
+    /// </summary>
+    public override void PrepareLighting(RenderContext context)
+    {
+        LightingUniforms.ApplyStandardLighting(this, context);
     }
 }

--- a/YinYang/Materials/mat_concrete.cs
+++ b/YinYang/Materials/mat_concrete.cs
@@ -1,7 +1,12 @@
 using OpenTK.Mathematics;
+using YinYang.Rendering;
 
 namespace YinYang.Materials;
 
+/// <summary>
+/// A basic concrete material with minimal reflectivity.
+/// Suitable for scenes that use lighting and shadow, but with low specular response.
+/// </summary>
 public class mat_concrete : Material
 {
     public mat_concrete() : base()
@@ -12,8 +17,16 @@ public class mat_concrete : Material
         uniforms.Add("material.diffuse", new Vector3(0.2f));
         uniforms.Add("material.specular", new Vector3(0.1f));
         uniforms.Add("material.shininess", 0.5f);
-        
+
         UpdateUniforms();
     }
-}
 
+    /// <summary>
+    /// Uses standard lighting setup for simple diffuse material.
+    /// Delegates to base implementation, unless specialized lighting is needed.
+    /// </summary>
+    public override void PrepareLighting(RenderContext context)
+    {
+        LightingUniforms.ApplyStandardLighting(this, context);
+    }
+}

--- a/YinYang/Materials/mat_glow.cs
+++ b/YinYang/Materials/mat_glow.cs
@@ -1,13 +1,27 @@
 using OpenTK.Mathematics;
+using YinYang.Rendering;
 
 namespace YinYang.Materials;
 
+/// <summary>
+/// A self-lit emissive material that does not receive or respond to lighting.
+/// Used for glow effects, UI markers, or post-process inputs.
+/// </summary>
 public class mat_glow : Material
 {
     public mat_glow() : base("Shaders/UnlitGeneric.vert", "Shaders/UnlitGeneric.frag")
     {
         uniforms.Add("color", new Vector3(1));
-        
         UpdateUniforms();
     }
+
+    /// <summary>
+    /// This material does not support lighting. This method is intentionally left blank.
+    /// </summary>
+    public override void PrepareLighting(RenderContext context) { }
+
+    /// <summary>
+    /// Prevents light uniforms from being set by default renderer logic.
+    /// </summary>
+    public override bool UsesLighting => false;
 }

--- a/YinYang/Rendering/HDRRenderPass.cs
+++ b/YinYang/Rendering/HDRRenderPass.cs
@@ -76,10 +76,9 @@ namespace YinYang.Rendering
             
             screenQuad.Draw();
        
-            //TODO: FIXME
-            /*var err = GL.GetError();
+            var err = GL.GetError();
             if (err != ErrorCode.NoError)
-                Console.WriteLine($"[GL ERROR] after {nameof(HDRRenderPass)}: {err}");*/
+                Console.WriteLine($"[GL ERROR] after {nameof(HDRRenderPass)}: {err}");
 
             return context.LightSpaceMatrix;
         }

--- a/YinYang/Rendering/Renderer.cs
+++ b/YinYang/Rendering/Renderer.cs
@@ -1,10 +1,15 @@
 ﻿using OpenTK.Graphics.OpenGL;
 using OpenTK.Mathematics;
 using YinYang.Materials;
-using YinYang.Worlds;
 
 namespace YinYang.Rendering
 {
+    /// <summary>
+    /// Responsible for rendering a mesh using its associated material and the current render context.
+    /// </summary>
+    /// <remarks>
+    /// Lighting and transformation logic moved to the material, enabling clean SOC.
+    /// </remarks>
     public class Renderer
     {
         private Material _material;
@@ -16,164 +21,52 @@ namespace YinYang.Rendering
             set
             {
                 if (_material != null && _material != value)
-                {
                     (_material as IDisposable)?.Dispose();
-                }
+
                 _material = value;
             }
         }
 
         public Mesh Mesh { get; set; }
-        
+
         public Renderer(Material material, Mesh mesh)
         {
             Material = material;
             Mesh = mesh;
         }
 
+        /// <summary>
+        /// Draws the mesh with the associated material using the provided rendering context and transforms.
+        /// </summary>
+        /// <param name="context">Shared per-frame render data (camera, lights, world, etc).</param>
+        /// <param name="mvp">Combined model-view-projection matrix.</param>
+        /// <param name="model">Local model transform matrix.</param>
         public void Draw(RenderContext context, Matrix4 mvp, Matrix4 model)
         {
-            // Bind shader and update global material data
             Material.UseShader();
             Material.UpdateUniforms();
             
-            // Setup Light
-            SetSun(context.World);
-            SpotLights(context.Camera, context.World);
-            PointLights(context.World);
+            // Set transform + camera data
+            Material.SetUniform("mvp", mvp);
+            Material.SetUniform("model", model);
+            Material.SetUniform("normalMatrix", Matrix4.Invert(model));
+            Material.SetUniform("viewPos", context.Camera.Position);
+            Material.SetUniform("debugMode", context.DebugMode);
 
-            // Transformation Uniforms
-            Material.SetUniform("mvp", mvp);                         // Combined Model-View-Projection matrix
-            Material.SetUniform("model", model);                     // Object's model matrix
-            
-            // Lighting Uniforms
-            Material.SetUniform("normalMatrix", Matrix4.Invert(model)); // Used for transforming normals in lighting
-            Material.SetUniform("lightSpaceMatrix", context.LightSpaceMatrix); // Used for shadow projection
-            Material.SetUniform("viewPos", context.Camera.Position);         // Camera position for specular lighting
-            Material.SetUniform("shadowMap", context.World.depthMap);       // Shadow depth texture
-            Material.SetUniform("far_plane", 50.0f);
-            Material.SetUniform("cubeMap", context.World.depthCubeMap);
+            if (Material.UsesLighting)
+                Material.PrepareLighting(context);
 
-            // Other Uniforms
-            Material.SetUniform("debugMode", context.DebugMode);            // Debug rendering toggle/switch
-
-            // Draw the mesh
             Mesh.Draw();
         }
 
-
-
-
-        // public void Draw(Matrix4 mvp, Matrix4 lightSpaceMatrix, Matrix4 model, Camera camera, int currentDebugMode, World currentWorld)
-        // {
-
-        //
-        //     
-        //     // Set the shader program and update uniforms
-        //     Material.UseShader();
-        //     Material.UpdateUniforms();
-        //     
-        //     // Set the uniforms for the shader
-        //     Material.SetUniform("mvp", mvp);
-        //     Material.SetUniform("model", model);
-        //     Material.SetUniform("lightSpaceMatrix", lightSpaceMatrix);
-        //
-        //     Material.SetUniform("shadowMap", currentWorld.depthMap);
-        //     Material.SetUniform("normalMatrix", Matrix4.Invert(model)); 
-        //     Material.SetUniform("viewPos", camera.Position);
-        //     Material.SetUniform("debugMode", currentDebugMode);
-        //
-        //
-        //     Matrix4 normalMatrix = Matrix4.Invert(model);
-        //
-        //     Material.SetUniform("normalMatrix", normalMatrix); 
-        //
-        //
-        //     // set lights
-        //
-        //     SetSun(currentWorld);
-        //     SpotLights(camera, currentWorld);
-        //     PointLights(currentWorld);
-        //
-        //     // Draw the mesh
-        //     Mesh.Draw();
-        // }
-
-        public void PointLights(World currentWorld)
-        {
-            int numPointLights = currentWorld.PointLights.Count;
-            
-            Material.SetUniform("numPointLights", numPointLights);
-            
-            for (int i = 0; i < numPointLights; i++)
-            {
-                //Position
-                Material.SetUniform($"pointLights[{i}].position", currentWorld.PointLights[i].Transform.Position);
-                
-                //Colors
-                Material.SetUniform($"pointLights[{i}].ambient", currentWorld.GetSkyColor() / 255);
-                Material.SetUniform($"pointLights[{i}].diffuse", currentWorld.PointLights[i].LightColor);
-                Material.SetUniform($"pointLights[{i}].specular", currentWorld.PointLights[i].LightColor);
-                
-                //Fall-off
-                Material.SetUniform($"pointLights[{i}].constant", currentWorld.PointLights[i].Constant);
-                Material.SetUniform($"pointLights[{i}].linear", currentWorld.PointLights[i].Linear);
-                Material.SetUniform($"pointLights[{i}].quadratic", currentWorld.PointLights[i].Quadratic);
-            }
-        }
-
-        public void SpotLights(Camera camera, World currentWorld)
-        {
-            int numSpotLights = currentWorld.SpotLights.Count;
-            Material.SetUniform("numSpotLights", numSpotLights);
-            
-            for (int i = 0; i < numSpotLights; i++)
-            {
-                //Position & rotation
-                if (i == 0) // spotlight 0 is ALWAYS player flashlight!!
-                {
-                    Material.SetUniform($"spotLights[{i}].position", camera.Position);
-                    Material.SetUniform($"spotLights[{i}].direction", Vector3.Normalize(camera.Front));
-                }
-                else //All other spotlights
-                {
-                    Material.SetUniform($"spotLights[{i}].position", currentWorld.SpotLights[i].Transform.Position);
-                    Material.SetUniform($"spotLights[{i}].direction", currentWorld.SpotLights[i].Transform.Rotation);
-                }
-
-                //Cone radius
-                Material.SetUniform($"spotLights[{i}].cutOff", (float)MathHelper.Cos(MathHelper.DegreesToRadians(
-                    currentWorld.SpotLights[i].InnerRadius)));
-                
-                Material.SetUniform($"spotLights[{i}].outerCutOff", (float)MathHelper.Cos(MathHelper.DegreesToRadians(
-                    currentWorld.SpotLights[i].OuterRadius)));
-                
-                //Color
-                Material.SetUniform($"spotLights[{i}].ambient", currentWorld.GetSkyColor() / 255);
-                Material.SetUniform($"spotLights[{i}].diffuse", currentWorld.SpotLights[i].LightColor);
-                Material.SetUniform($"spotLights[{i}].specular", currentWorld.SpotLights[i].LightColor);
-                
-                //Fall-off
-                Material.SetUniform($"spotLights[{i}].constant", currentWorld.SpotLights[i].Constant);
-                Material.SetUniform($"spotLights[{i}].linear", currentWorld.SpotLights[i].Linear);
-                Material.SetUniform($"spotLights[{i}].quadratic", currentWorld.SpotLights[i].Quadratic);
-            }
-        }
-
-        public void SetSun(World currentWorld)
-        {
-            Material.SetUniform("dirLight.direction", currentWorld.DirectionalLight.Transform.Rotation);
-            Material.SetUniform("dirLight.ambient", currentWorld.GetSkyColor() / 2);
-            Material.SetUniform("dirLight.diffuse", currentWorld.DirectionalLight.LightColor);
-            Material.SetUniform("dirLight.specular", currentWorld.DirectionalLight.LightColor);
-        }
-
+        /// <summary>
+        /// Draws the mesh using only depth information, used in shadow passes.
+        /// </summary>
         public void RenderDepth(Shader shader, Matrix4 model)
         {
             shader.SetMatrix("model", model);
             GL.DepthMask(DepthTest);
             Mesh.Draw();
-            
             GL.DepthMask(true);
         }
     }

--- a/YinYang/Rendering/SceneRenderPass.cs
+++ b/YinYang/Rendering/SceneRenderPass.cs
@@ -34,10 +34,9 @@ namespace YinYang.Rendering
             // Render all objects using lighting and transformation data
             objects.Render(context);
             
-            //TODO: FIXME
-            /*var err = GL.GetError();
+            var err = GL.GetError();
             if (err != ErrorCode.NoError)
-                Console.WriteLine($"[GL ERROR - SCENE RENDER PASS] after {nameof(SceneRenderPass)}: {err}");*/
+                Console.WriteLine($"[GL ERROR - SCENE RENDER PASS] after {nameof(SceneRenderPass)}: {err}");
 
             // Return the same light-space matrix to pass along to any subsequent render passes
             return context.LightSpaceMatrix;

--- a/YinYang/Rendering/ShadowRenderPass.cs
+++ b/YinYang/Rendering/ShadowRenderPass.cs
@@ -113,10 +113,9 @@ namespace YinYang.Rendering
         // Unbind the framebuffer to return to the default target.
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
 
-        //TODO: FIXME
-        /*var err = GL.GetError();
+        var err = GL.GetError();
         if (err != ErrorCode.NoError)
-            Console.WriteLine($"[GL ERROR] after {nameof(ShadowRenderPass)}: {err}");*/
+            Console.WriteLine($"[GL ERROR] after {nameof(ShadowRenderPass)}: {err}");
         
         // Return the transformation matrix for use in the main lighting pass.
         return lightSpaceMatrix;


### PR DESCRIPTION
- Removed all lighting setup code from Renderer (SetSun, PointLights, SpotLights)
- Delegated lighting configuration to each material via PrepareLighting override
- Introduced LightingUniforms static helper for shared directional, point, and spot light setup
- Added UsesLighting flag to Material to skip lighting logic for unlit shaders
- Updated mat_chrome and mat_concrete to use shared lighting helper
- Ensured mat_glow opts out of lighting setup entirely